### PR TITLE
Add draft schedule

### DIFF
--- a/workshop/SCHEDULE.md
+++ b/workshop/SCHEDULE.md
@@ -3,18 +3,53 @@ title: Workshop Schedule
 nav_title: Schedule
 ---
 
-<!--See an example from a past remote workshop here: https://github.com/AlexsLemonade/2024-june-training/blob/main/workshop/SCHEDULE.md -->
-<!--See an example from a past in-person workshop here: https://github.com/AlexsLemonade/2024-december-training/blob/main/workshop/SCHEDULE.md -->
+The planned schedule for the March 2025 Data Lab Virtual Training Workshop "Introduction to Single-Cell RNA-Seq" appears below.
 
 
-| Time        | Topic
-|-------------|------------------------------------------------
-| **Day 1**   | **Date** <br> **Topic**
-| 12:00 PM    | Welcome, Introductions and Getting Started
-|             | [Welcome Slides (PDF)](../slides/Workshop_Introduction.pdf)
-| 5:00        | End
-| **Day 2**   | **Date**
-| **Day 3**   | **Date**
-| **Day 4**   | **Date**
-| **Day 5**   | **Date**
-| 5:00        | Adjourn
+*Note: All times are [EDT (UTC−04:00)](https://www.timeanddate.com/time/zones/edt).*
+
+
+| Time        | Topic                             | Location |
+|-------------|--------------------------------------------|----------------|
+| **Day 1**   | **2025-03-24** <br> _**Introduction to R and the Tidyverse**_                 |
+| 12:00 PM    | Welcome, Introductions and Getting Started <br> [Workshop introduction slides (PDF)](#../slides/2025-03-24_course-intro-scRNA.pdf)  | Zoom: [Main Session](../software-setup/zoom-procedures.md) |
+| 1:00 PM     | [Introduction to base R](#../completed-notebooks/intro-to-R-tidyverse/01-intro_to_base_R.nb.html) <br> [Introduction to R, RStudio, and RStudio Server slides (PDF)](#../slides/2025-03-10_intro-to-r-rstudio.pdf) | Zoom: [Main Session](../software-setup/zoom-procedures.md)|
+| 2:30 PM     | [Introduction to `ggplot2`](#../completed-notebooks/intro-to-R-tidyverse/02-intro_to_ggplot2.nb.html) | Zoom: [Main Session](../software-setup/zoom-procedures.md) |
+| 3:30 PM     | [Introduction to the `tidyverse`](#../completed-notebooks/intro-to-R-tidyverse/03-intro_to_tidyverse.nb.html) | Zoom: [Main Session](../software-setup/zoom-procedures.md) |
+| 4:30 PM     | Questions and introduction to the exercises | Zoom: [Breakout Rooms](../software-setup/zoom-procedures.md#using-breakout-rooms) |
+|             | [Exercise: Introduction to base R](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/exercise_01-intro_to_base_R.Rmd)  | |
+|             | [Exercise: Introduction to R](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/exercise_02-intro_to_R.Rmd)  | |
+|             | [Exercise: Introduction to the `tidyverse`, Part 1](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/exercise_03a-intro_to_tidyverse.Rmd)  | |
+|             | [Exercise: Introduction to the `tidyverse`, Part 2](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/exercise_03b-intro_to_tidyverse.Rmd)  | |
+|             | Exercises and [consultation sessions](workshop-logistics.md#consultation-sessions) | [Slack channel](../software-setup/slack-procedures.md) |
+| 5:00  PM    | *Adjourn for the day*             |
+| | |         |
+| **Day 2**   | **2025-03-25**  <br> _**Introduction to Single-cell RNA-seq, Day 1**_ |
+| 12:00 PM    | Introduction <br> [Introduction to scRNA-seq slides (PDF)](#../slides/2025-03-25_Intro_to_scRNA-seq.pdf) | Zoom: [Main Session](../software-setup/zoom-procedures.md) |
+| 12:30 PM    | [scRNA-seq quantification with Alevin](#../completed-notebooks/scRNA-seq/01-scRNA_quant_qc.nb.html) | Zoom: [Main Session](../software-setup/zoom-procedures.md)|
+| 1:30 PM     | [Importing data and filtering cells](#../completed-notebooks/scRNA-seq/02-filtering_scRNA.nb.html) | Zoom: [Main Session](../software-setup/zoom-procedures.md) |
+| 2:30 PM     | [Normalization of expression data](#../completed-notebooks/scRNA-seq/03-normalizing_scRNA.nb.html) | Zoom: [Main Session](../software-setup/zoom-procedures.md) |
+| 3:30 PM     | Questions and introduction to the exercise | Zoom: [Breakout Rooms](../software-setup/zoom-procedures.md#using-breakout-rooms) |
+|             | [Exercise: scRNA-seq quantification](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/exercise_01-scrna_quant.Rmd) | |
+|             | Exercises and [consultation sessions](workshop-logistics.md#consultation-sessions) | [Slack channel](../software-setup/slack-procedures.md) |
+| 5:00  PM    | *Adjourn for the day*             |
+| | |         |
+| **Day 3**   | **2025-03-26**  <br> _**Introduction to Single-cell RNA-seq, Day 2**_ |
+| 12:00 PM    | [Dimension reduction & visualization](#../completed-notebooks/scRNA-seq/04-dimension_reduction_scRNA.nb.html) <br> [Dimension reduction and clustering slides (PDF)](#../slides/2025-03-26_dimension-reduction-clustering.pdf) | Zoom: [Main Session](../software-setup/zoom-procedures.md)|
+| 1:30 PM     | [Clustering and marker identification](#../completed-notebooks/scRNA-seq/05-clustering_markers_scRNA.nb.html) | Zoom: [Main Session](../software-setup/zoom-procedures.md) |
+| 3:00 PM     | Questions and introduction to the exercise | Zoom: [Breakout Rooms](../software-setup/zoom-procedures.md#using-breakout-rooms) |
+|             | [Exercise: scRNA-seq clustering](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/exercise_02-scrna_clustering.Rmd) | |
+|             | Exercises and [consultation sessions](workshop-logistics.md#consultation-sessions) | [Slack channel](../software-setup/slack-procedures.md) |
+| 5:00  PM    | *Adjourn for the day*             |
+| | |    |
+| **Day 4**   | **2025-03-27**  <br> _**Introduction to Single-cell RNA-seq, Day 3**_ | |
+| 12:00 PM    | [Cell type annotation](#../completed-notebooks/scRNA-seq/06-celltype_annotation.nb.html) <br> [Cell type annotation slides (PDF)](#../slides/2025-03-27_cell-type-assignment.pdf) | Zoom: [Main Session](../software-setup/zoom-procedures.md) |
+| 2:30 PM     | Questions and introduction to the exercise | Zoom: [Breakout Rooms](../software-setup/zoom-procedures.md#using-breakout-rooms) |
+|             | Exercises and [consultation sessions](workshop-logistics.md#consultation-sessions) | [Slack channel](../software-setup/slack-procedures.md)|
+|             | [Exercise: scRNA-seq cell type annotation](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/exercise_03-celltype.Rmd) | |
+| 5:00  PM    | *Adjourn for the day*             |
+| | |
+| **Day 5**   | **2025-03-28**  <br> _**Consultation and Presentations**_ |
+| 12:00 PM    | [Consultation sessions](workshop-logistics.md#consultation-sessions)  | [Slack channel](../software-setup/slack-procedures.md) |
+| 2:30 PM     | [Participant presentations begin](workshop-logistics.md#participant-presentations) | Zoom: [Main Session](../software-setup/zoom-procedures.md) |
+| 5:00 PM     | *Adjourn*   |

--- a/workshop/SCHEDULE.md
+++ b/workshop/SCHEDULE.md
@@ -13,7 +13,7 @@ The planned schedule for the March 2025 Data Lab Virtual Training Workshop "Intr
 |-------------|--------------------------------------------|----------------|
 | **Day 1**   | **2025-03-24** <br> _**Introduction to R and the Tidyverse**_                 |
 | 12:00 PM    | Welcome, Introductions and Getting Started <br> [Workshop introduction slides (PDF)](#../slides/2025-03-24_course-intro-scRNA.pdf)  | Zoom: [Main Session](../software-setup/zoom-procedures.md) |
-| 1:00 PM     | [Introduction to base R](#../completed-notebooks/intro-to-R-tidyverse/01-intro_to_base_R.nb.html) <br> [Introduction to R, RStudio, and RStudio Server slides (PDF)](#../slides/2025-03-10_intro-to-r-rstudio.pdf) | Zoom: [Main Session](../software-setup/zoom-procedures.md)|
+| 1:00 PM     | [Introduction to base R](#../completed-notebooks/intro-to-R-tidyverse/01-intro_to_base_R.nb.html) <br> [Introduction to R, RStudio, and RStudio Server slides (PDF)](#../slides/2025-03-24_intro-to-r-rstudio.pdf) | Zoom: [Main Session](../software-setup/zoom-procedures.md)|
 | 2:30 PM     | [Introduction to `ggplot2`](#../completed-notebooks/intro-to-R-tidyverse/02-intro_to_ggplot2.nb.html) | Zoom: [Main Session](../software-setup/zoom-procedures.md) |
 | 3:30 PM     | [Introduction to the `tidyverse`](#../completed-notebooks/intro-to-R-tidyverse/03-intro_to_tidyverse.nb.html) | Zoom: [Main Session](../software-setup/zoom-procedures.md) |
 | 4:30 PM     | Questions and introduction to the exercises | Zoom: [Breakout Rooms](../software-setup/zoom-procedures.md#using-breakout-rooms) |


### PR DESCRIPTION
Closes #5 

This PR adds the draft schedule. As we did for June 2024, I used [anchor links](https://github.com/AlexsLemonade/2024-june-training/pull/12#pullrequestreview-2073916953) for slides and completed notebooks to save us some time typing later. I will add a comment to #4 for future us so we know how to update here later.